### PR TITLE
ver. 3.0.0: gather URL instead of Key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-JIRA_BASE_URL=https://super-puper.atlassian.net/
+JIRA_BASE_URL=https://super-puper.atlassian.net
 JIRA_TOKEN_BASE_64=123

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 4. Add base URL to `.env` file as `JIRA_BASE_URL` (check `.env.example` file)
 
 ### CSV build config
-*Curious Goran will add "key" and "title" to resulted CSV. So you shouldn't use these fields in the csv-build-convig.json*
+*Curious Goran will add "url" and "title" to resulted CSV. So you shouldn't use these fields in the csv-build-convig.json*
 1. Check `/data/csv-build-config.example.json` file.
 2. Add your own statuses to the csv in the order you would like.
 3. Rename `csv-build-config.example.json` to `csv-build-config.json`

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -1,9 +1,13 @@
 import { JiraTicketHistory, Transition, Ticket, JiraTicket, StatusSwitches, StatusSwitchString } from "./types";
 import {
     calculateHowMuchTimeWasInEveryStatus,
+    makeJiraTicketUrl,
     withoutNull,
 } from "./utils";
-import { config } from "./config";
+import { config as curiousGoranConfig } from "./config";
+
+import { config } from "dotenv";
+config();
 
 const makeTransitionsFromChangelogHistory = (history: JiraTicketHistory) => {
     const { created, items } = history;
@@ -52,11 +56,17 @@ const calculateSwitches = (item: Transition): StatusSwitches => {
 }
 
 export const createTickets = (data: JiraTicket[]): Ticket[] => {
+    const baseUrl = process.env.JIRA_BASE_URL;
+
+    if (!baseUrl) {
+        throw new Error("You didn't specify JIRA_BASE_URL in the .env file.");
+    }
+
     return makeTransitions(data).map((item) => {
         return {
-            key: item.key,
+            url: makeJiraTicketUrl(baseUrl, item.key),
             title: item.title,
-            timeInStatuses: calculateHowMuchTimeWasInEveryStatus(config, item),
+            timeInStatuses: calculateHowMuchTimeWasInEveryStatus(curiousGoranConfig, item),
             switchesBetweenStatuses: calculateSwitches(item),
         };
     });

--- a/src/get.ts
+++ b/src/get.ts
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { createWriteStream } from "fs";
 
 import { config } from "dotenv";
 config();
@@ -7,7 +6,7 @@ config();
 import { JiraTicket } from "./types";
 
 const AXIOS_INSTANCE = axios.create({
-  baseURL: process.env.JIRA_BASE_URL + "rest/api/2/",
+  baseURL: process.env.JIRA_BASE_URL + "/rest/api/2/",
   timeout: 15000,
   headers: {
     Authorization: `Basic ${process.env.JIRA_TOKEN_BASE_64}`,

--- a/src/make-csv.ts
+++ b/src/make-csv.ts
@@ -8,11 +8,11 @@ export const buildCsv = (
 ): Csv => {
   const result: CsvPresentation = [];
   const { interestedStatusesForTimeCalculations, switchesBetweenStatuses } = csvBuildConfig;
-  const accumulatedArrays = ["key", "title", ...interestedStatusesForTimeCalculations, ...switchesBetweenStatuses];
+  const accumulatedArrays = ["url", "title", ...interestedStatusesForTimeCalculations, ...switchesBetweenStatuses];
 
   result.push(accumulatedArrays.join(", "));
 
-  tickets.forEach(({ key, title, timeInStatuses, switchesBetweenStatuses }) => {
+  tickets.forEach(({ url, title, timeInStatuses, switchesBetweenStatuses }) => {
     const sum = { ...timeInStatuses, ...switchesBetweenStatuses };
 
     const csvRow: (string | number | null)[] = accumulatedArrays.map((item) => {
@@ -22,7 +22,7 @@ export const buildCsv = (
 
       return config.setZeroInsteadOfNull ? 0 : null;
     });
-    csvRow[0] = key;
+    csvRow[0] = url;
     csvRow[1] = title;
 
     result.push(csvRow.join(", "));

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,11 @@ export type CsvRow = string;
 
 export type JiraTicketStatus = string;
 
+// example: RET-666
+export type JiraTicketKey = string;
+
+export type JiraTicketUrl = string;
+
 export type JiraTicketTitle = string;
 
 // example: "In review -> In progress"
@@ -20,7 +25,7 @@ export type Count = number;
 export type StatusSwitches = Record<StatusSwitchString, Count>;
 
 export interface Ticket {
-  key: string;
+  key: JiraTicketKey;
   title: JiraTicketTitle;
   timeInStatuses: TimeInStatus;
   switchesBetweenStatuses: StatusSwitches;
@@ -29,7 +34,7 @@ export interface Ticket {
 export type TimeInStatus = Record<JiraTicketStatus, number>;
 
 export interface Transition {
-  key: string;
+  key: JiraTicketKey;
   title: JiraTicketTitle;
   transitions: {
     when: string;
@@ -50,7 +55,7 @@ export interface JiraTicketHistory {
 }
 
 export interface JiraTicket {
-  key: string;
+  key: JiraTicketKey;
   fields: {
     summary: JiraTicketTitle;
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export type Count = number;
 export type StatusSwitches = Record<StatusSwitchString, Count>;
 
 export interface Ticket {
-  key: JiraTicketKey;
+  url: JiraTicketUrl;
   title: JiraTicketTitle;
   timeInStatuses: TimeInStatus;
   switchesBetweenStatuses: StatusSwitches;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,9 @@
 import { DateTime, Duration } from "luxon";
 import { Config } from "./config";
 import {
-  Csv,
-  CsvPresentation,
-  CsvRow,
-  CsvBuildConfig,
+  JiraTicketKey,
+  JiraTicketUrl,
   TimeInStatus,
-  Ticket,
   Transition,
 } from "./types";
 
@@ -72,3 +69,7 @@ export const calculateHowMuchTimeWasInEveryStatus = (
     return acc;
   }, {});
 };
+
+export const makeJiraTicketUrl = (baseUrl: string, jiraTicketKey: JiraTicketKey): JiraTicketUrl => {
+  return `${baseUrl}/browse/${jiraTicketKey}`;
+}

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -10,6 +10,38 @@ import {
   withoutNull,
 } from "../src/utils";
 
+const JIRA_BASE_URL_FOR_TESTING = 'https://super-puper.com';
+const jiraTicketsData = require('./jira-tickets-data.json') as JiraTicket[];
+
+test("createTickets", () => {
+  process.env.JIRA_BASE_URL = JIRA_BASE_URL_FOR_TESTING;
+
+  assert.equal(createTickets(jiraTicketsData), [
+    {
+      "url": `${JIRA_BASE_URL_FOR_TESTING}/browse/RET-3072`,
+      "title": "[Web] Treatment Monitoring Release Manager: add an error when it finds that it is a release branch with the same version as the lates release",
+      "timeInStatuses": {
+        "In progress": 0,
+        "In Review": 0,
+        "Tested": 0,
+        "Ready to release": 325
+      },
+      "switchesBetweenStatuses": {
+        "To Do -> In progress": 1,
+        "In progress -> In Review": 1,
+        "In Review -> Tested": 1,
+        "Tested -> Ready to release": 1,
+        "Ready to release -> Done": 1
+      }
+    }
+  ]);
+});
+
+test("createTickets: user forget to set JIRA_BASE_URL environment variable", () => {
+  process.env.JIRA_BASE_URL = '';
+  assert.throws(() => createTickets(jiraTicketsData));
+});
+
 test("sliced pairs for numbers", () => {
   assert.equal(createSlicedPairsFromArray([1, 2, 3]), [
     [1, 2],
@@ -183,7 +215,7 @@ test("buildCsv with empty spaces", () => {
     buildCsv(
       [
         {
-          key: "RET-2922",
+          url: `${JIRA_BASE_URL_FOR_TESTING}/browse/RET-2922`,
           title: "something for test",
           timeInStatuses: {
             "In progress": 0,
@@ -198,7 +230,7 @@ test("buildCsv with empty spaces", () => {
       csvBuildConfig1,
       { setZeroInsteadOfNull: false }
     ),
-    [["key", "title", ...csvBuildConfig1.interestedStatusesForTimeCalculations].join(", "), "RET-2922, something for test, , 0"].join("\n")
+    [["url", "title", ...csvBuildConfig1.interestedStatusesForTimeCalculations].join(", "), `${JIRA_BASE_URL_FOR_TESTING}/browse/RET-2922, something for test, , 0`].join("\n")
   );
 });
 
@@ -207,7 +239,7 @@ test("buildCsv with zeros", () => {
     buildCsv(
       [
         {
-          key: "RET-2922",
+          url: `${JIRA_BASE_URL_FOR_TESTING}/browse/RET-2922`,
           title: "something for test",
           timeInStatuses: {
             "In progress": 0,
@@ -222,36 +254,14 @@ test("buildCsv with zeros", () => {
       csvBuildConfig1,
       { setZeroInsteadOfNull: true }
     ),
-    ["key, title, Waiting for Development, In Testing", "RET-2922, something for test, 0, 0"].join("\n")
+    ["url, title, Waiting for Development, In Testing", `${JIRA_BASE_URL_FOR_TESTING}/browse/RET-2922, something for test, 0, 0`].join("\n")
   );
 });
 
-const jiraTicketsData = require('./jira-tickets-data.json') as JiraTicket[];
-test("Convert JiraTicket to Ticket", () => {
-  assert.equal(createTickets(jiraTicketsData), [
-    {
-      "key": "RET-3072",
-      "title": "[Web] Treatment Monitoring Release Manager: add an error when it finds that it is a release branch with the same version as the lates release",
-      "timeInStatuses": {
-        "In progress": 0,
-        "In Review": 0,
-        "Tested": 0,
-        "Ready to release": 325
-      },
-      "switchesBetweenStatuses": {
-        "To Do -> In progress": 1,
-        "In progress -> In Review": 1,
-        "In Review -> Tested": 1,
-        "Tested -> Ready to release": 1,
-        "Ready to release -> Done": 1
-      }
-    }
-  ]);
-});
 
 test("buildCsv: make a CSV with switches", () => {
   const tickets = [{
-    "key": "RET-3027",
+    "url": `${JIRA_BASE_URL_FOR_TESTING}/browse/RET-3027`,
     "title": "something for test",
     "timeInStatuses": {
       "In progress": 0,
@@ -273,7 +283,7 @@ test("buildCsv: make a CSV with switches", () => {
     switchesBetweenStatuses: ["To Do -> In progress"]
   };
 
-  assert.equal(buildCsv(tickets, csvBuildConfig, { setZeroInsteadOfNull: true }), "key, title, To Do -> In progress\nRET-3027, something for test, 1")
+  assert.equal(buildCsv(tickets, csvBuildConfig, { setZeroInsteadOfNull: true }), `url, title, To Do -> In progress\n${JIRA_BASE_URL_FOR_TESTING}/browse/RET-3027, something for test, 1`)
 })
 
 test("makeJiraTicketUrl function", () => {

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -6,6 +6,7 @@ import { CsvBuildConfig, JiraTicket } from "../src/types";
 import {
   calculateHowMuchTimeWasInEveryStatus,
   createSlicedPairsFromArray,
+  makeJiraTicketUrl,
   withoutNull,
 } from "../src/utils";
 
@@ -273,6 +274,10 @@ test("buildCsv: make a CSV with switches", () => {
   };
 
   assert.equal(buildCsv(tickets, csvBuildConfig, { setZeroInsteadOfNull: true }), "key, title, To Do -> In progress\nRET-3027, something for test, 1")
+})
+
+test("makeJiraTicketUrl function", () => {
+  assert.equal(makeJiraTicketUrl('https://super-base.jira.com', 'RET-666'), 'https://super-base.jira.com/browse/RET-666')
 })
 
 test.run();


### PR DESCRIPTION
breaking changes:
- JIRA_BASE_URL env. variable shouldn't use a trailing slash
- Curious Goran gathers a URL of Jira ticket instead of a key